### PR TITLE
feat: Thêm logic kiểm tra, khóa đề thi Premium, chức năng nút thoát & submit

### DIFF
--- a/client/js/exam.js
+++ b/client/js/exam.js
@@ -1,50 +1,60 @@
 document.addEventListener('DOMContentLoaded', () => {
-    // 1. LUÔN LUÔN VẼ SIDEBAR TRƯỚC
-    // Đã thêm vào hàm fetchExamData(), không cần vẽ trước đâu.
+    // --- TÍNH NĂNG MỚI: Phân biệt F5  và Vào mới ---
+    // Kiểm tra xem user nhấn F5 hay là mới đi từ trang ngoài vào
+    const navEntries = performance.getEntriesByType("navigation");
+    const isReload = navEntries.length > 0 
+        ? navEntries[0].type === "reload" 
+        : (window.performance && performance.navigation.type === 1);
+    if (!isReload) {
+        clearExamData(); 
+    }
 
-    // 2. Kích hoạt tính năng Audio chỉ cho nghe 1 lần
+    // Kích hoạt tính năng Audio chỉ cho nghe 1 lần
     setupAudioOnce();
 
-    // 3. Mọi thứ giao diện đã ổn định, giờ mới đi lấy dữ liệu
+    // Mọi thứ giao diện đã ổn định, giờ mới đi lấy dữ liệu
     fetchExamData();
 });
-
 
 //Gọi dữ liệu từ db
 async function fetchExamData() {
     try {
         const params = new URLSearchParams(window.location.search);
         const uuid = params.get("uuid") || params.get("test_id");
-
-        //Lấy đề thi bằng uuid
+       // Lấy đề thi bằng uuid
         const response = await fetch(`/api/tests/${uuid}`);
+        // 1. CHẶN NGAY TỪ CỬA NẾU BACKEND BÁO LỖI 403 (CHƯA MUA ĐỀ)
+        if (response.status === 403) {
+            alert("Đề thi này dành riêng cho tài khoản đã mua!");
+            window.location.href = "/client/pages/premium.php"; 
+            return; // Dừng tại đây, không tải dữ liệu nữa
+        }
+
+        // 2. Bắt các lỗi khác (ví dụ 404 không tìm thấy đề, 500 lỗi server...)
         if (!response.ok) {
             throw new Error("Could not fetch resource (function in exam.js)");
         }
+
+        // 3. Nếu mọi thứ ok (response 200) thì mới lôi data ra 
         const questions_lists = await response.json();
         const questions = questions_lists.data.questions;
         const examData = questions_lists.data;
-        // Giả sử API trả về cờ is_premium và has_purchased
-        if (examData.is_premium === 1 && !examData.has_purchased) {
-            alert("Đây là đề thi Premium. Bạn cần nâng cấp tài khoản hoặc mua bộ đề này để làm bài!");
-            window.location.href = "/client/pages/premium.php"; // Redirect
-            return; // Chặn không cho chạy code bên dưới
-        }
         const testDuration = Number(questions_lists.data.duration);
 
-        setupExamAudio(questions); //Fetch link audio
-        renderQuestions(questions); //In ra question và passage dựa trên test uuid
-        renderPartNav(questions); //In ra thanh navBar ở dưới thanh audio
+        setupExamAudio(questions); // Fetch link audio
+        renderQuestions(questions); // In ra question và passage
+        renderPartNav(questions); // In ra thanh navBar ở dưới thanh audio
 
-        //Đổi title thành title của đề thi
+        // Đổi title thành title của đề thi
         let title = document.getElementById("exam-title");
         title.innerHTML = questions_lists.data.title;  
         
+        renderSidebar(questions); // Render side bar dựa vào tổng số câu hỏi
         
-        renderSidebar(questions); //Render side bar dựa vào tổng số câu hỏi
-        // Truyền uuid vào để làm khóa lưu trữ riêng biệt cho từng đề thi
-        setupAnswerTracking(uuid); //Để chọn các options a,b,c,d
-        startTimer(Number.isFinite(testDuration) && testDuration > 0 ? testDuration : 120 * 60, uuid); //Lấy test duration trong database và đếm ngược
+        // Truyền uuid vào để làm khóa lưu trữ riêng biệt
+        setupAnswerTracking(uuid); 
+        // Lấy test duration trong database và đếm ngược
+        startTimer(Number.isFinite(testDuration) && testDuration > 0 ? testDuration : 120 * 60, uuid); 
 
     } catch (error) {
         console.error("Lỗi khi kết nối Database:", error);

--- a/client/js/exam.js
+++ b/client/js/exam.js
@@ -14,15 +14,22 @@ document.addEventListener('DOMContentLoaded', () => {
 async function fetchExamData() {
     try {
         const params = new URLSearchParams(window.location.search);
-        const uuid = params.get("uuid");
+        const uuid = params.get("uuid") || params.get("test_id");
 
         //Lấy đề thi bằng uuid
-        const response = await fetch(`../../api/tests/${uuid}`);
+        const response = await fetch(`/api/tests/${uuid}`);
         if (!response.ok) {
             throw new Error("Could not fetch resource (function in exam.js)");
         }
         const questions_lists = await response.json();
         const questions = questions_lists.data.questions;
+        const examData = questions_lists.data;
+        // Giả sử API trả về cờ is_premium và has_purchased
+        if (examData.is_premium === 1 && !examData.has_purchased) {
+            alert("Đây là đề thi Premium. Bạn cần nâng cấp tài khoản hoặc mua bộ đề này để làm bài!");
+            window.location.href = "/client/pages/premium.php"; // Redirect
+            return; // Chặn không cho chạy code bên dưới
+        }
         const testDuration = Number(questions_lists.data.duration);
 
         setupExamAudio(questions); //Fetch link audio
@@ -35,8 +42,9 @@ async function fetchExamData() {
         
         
         renderSidebar(questions); //Render side bar dựa vào tổng số câu hỏi
-        setupAnswerTracking(); //Để chọn các options a,b,c,d
-        startTimer(Number.isFinite(testDuration) && testDuration > 0 ? testDuration : 120 * 60); //Lấy test duration trong database và đếm ngược
+        // Truyền uuid vào để làm khóa lưu trữ riêng biệt cho từng đề thi
+        setupAnswerTracking(uuid); //Để chọn các options a,b,c,d
+        startTimer(Number.isFinite(testDuration) && testDuration > 0 ? testDuration : 120 * 60, uuid); //Lấy test duration trong database và đếm ngược
 
     } catch (error) {
         console.error("Lỗi khi kết nối Database:", error);
@@ -248,14 +256,31 @@ function renderSidebar(questions) {
 
 
 //Chọn đáp án
-function setupAnswerTracking() {
+function setupAnswerTracking(examUuid) {
     const radioInputs = document.querySelectorAll('.form-check-input');
     const qBoxes = document.querySelectorAll('.q-box');
-
-    // A. Tô màu xanh khi chọn đáp án
+// --- TÍNH NĂNG MỚI: Khôi phục đáp án nếu lỡ F5 ---
+    const storageKey = `exam_answers_${examUuid}`;
+    let savedAnswers = JSON.parse(localStorage.getItem(storageKey)) || {};
     radioInputs.forEach(input => {
+        const qNumber = input.name.replace('q', '');
+        
+        // 1. Kiểm tra xem câu này lúc trước đã chọn chưa, nếu có thì tích lại
+        if (savedAnswers[qNumber] === input.value) {
+            input.checked = true;
+            qBoxes.forEach(box => {
+                if (box.innerText.trim() === qNumber) {
+                    box.classList.add('answered');
+                }
+            });
+        }
+
+        // 2. Lắng nghe hành động user chọn đáp án mới
         input.addEventListener('change', function() {
-            const qNumber = this.name.replace('q', '');
+            // Lưu vào localStorage ngay lập tức
+            savedAnswers[qNumber] = this.value;
+            localStorage.setItem(storageKey, JSON.stringify(savedAnswers));
+
             qBoxes.forEach(box => {
                 if (box.innerText.trim() === qNumber) {
                     box.classList.add('answered');
@@ -265,19 +290,16 @@ function setupAnswerTracking() {
         });
     });
 
-    //Click ô vuông cuộn tới câu hỏi
+    // Phần click cuộn trang giữ nguyên
     qBoxes.forEach(box => {
         box.addEventListener('click', function() {
             const qNum = this.innerText.trim();
             const targetQuestion = document.getElementById(`question-${qNum}`);
-            
             if (targetQuestion) {
                 scrollToQuestionTarget(targetQuestion);
                 qBoxes.forEach(b => b.classList.remove('active'));
                 this.classList.add('active');
-                window.setTimeout(() => {
-                    this.classList.remove('active');
-                }, 1200);
+                window.setTimeout(() => { this.classList.remove('active'); }, 1200);
             }
         });
     });
@@ -286,34 +308,39 @@ function setupAnswerTracking() {
 
 //Đếm ngược dựa trên test duration
 let timerInterval = null;
-function startTimer(totalSeconds) {
-    // Sửa 1 & 2: Chữ 'd' viết thường và bỏ dấu '#'
+function startTimer(totalSeconds, examUuid) {
     const timerDisplay = document.getElementById('timer-display'); 
-    
-    // Check an toàn: Nếu không tìm thấy thẻ HTML đồng hồ thì thoát luôn để khỏi lỗi
     if (!timerDisplay) return; 
 
-    if (timerInterval) {
-        clearInterval(timerInterval);
-    }
+    if (timerInterval) clearInterval(timerInterval);
 
-    let time = totalSeconds;
+    // --- TÍNH NĂNG MỚI: Logic chống hack giờ bằng LocalStorage ---
+    const storageKey = `exam_endTime_${examUuid}`;
+    let endTime = localStorage.getItem(storageKey);
+
+    if (!endTime) {
+        // Nếu user mới vào lần đầu, lấy Giờ hiện tại + Tổng số giây làm bài
+        endTime = Date.now() + (totalSeconds * 1000);
+        localStorage.setItem(storageKey, endTime);
+    } else {
+        // Nếu user F5, lấy lại cái mốc giờ đã lưu
+        endTime = parseInt(endTime, 10);
+    }
     
     timerInterval = setInterval(() => {
-        const minutes = Math.floor(time / 60);
-        const seconds = time % 60;
+        const now = Date.now();
+        // Tính thời gian còn lại (đổi từ mili-giây ra giây)
+        const timeLeft = Math.max(0, Math.floor((endTime - now) / 1000));
         
-        const formattedTime = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        const minutes = Math.floor(timeLeft / 60);
+        const seconds = timeLeft % 60;
+        timerDisplay.innerText = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`; 
         
-        // Sửa 3: Gán thẳng text vào thẻ luôn, KHÔNG dùng forEach
-        timerDisplay.innerText = formattedTime; 
-        
-        if (time <= 0) {
+        if (timeLeft <= 0) {
             clearInterval(timerInterval);
+            localStorage.removeItem(storageKey); // Xóa bộ nhớ giờ
             alert('Đã hết thời gian làm bài! Hệ thống tự động nộp bài.');
-            // TODO: Bổ sung code tự động bấm nút nộp bài ở đây
-        } else {
-            time--;
+            submitExam(); // Tự động gọi hàm nộp bài
         }
     }, 1000);
 }
@@ -403,53 +430,59 @@ function setupAudioOnce() {
     audioEl.addEventListener('contextmenu', e => e.preventDefault());
 }
 
-// Đừng quên gọi hàm này khi trang web tải xong nhé:
-document.addEventListener("DOMContentLoaded", function() {
-    setupAudioOnce();
-});
-
-
 // Hàm này sẽ được gọi khi bạn bấm nút "Đồng ý" trong Modal
 async function submitExam() {
-    // 1. Ẩn modal ngay lập tức để user không bấm 2 lần
     var modalElement = document.getElementById('confirmSubmitModal');
-    var modalInstance = bootstrap.Modal.getInstance(modalElement);
-    if (modalInstance) {
+    if (modalElement) {
+        var modalInstance = bootstrap.Modal.getInstance(modalElement) || new bootstrap.Modal(modalElement);
         modalInstance.hide();
     }
 
-    // 2. Thu thập đáp án của người dùng
-    // const userAnswers = collectAnswers(); 
+    const params = new URLSearchParams(window.location.search);
+    const uuid = params.get("uuid") || params.get("test_id");
+
+    // Lấy nguyên cục đáp án từ bộ nhớ mà lúc nãy mình lưu
+    const storageKey = `exam_answers_${uuid}`;
+    const userAnswers = JSON.parse(localStorage.getItem(storageKey)) || {};
+
+    // Gom dữ liệu chuẩn bị gửi
+    const payload = {
+        test_uuid: uuid, 
+        answers: userAnswers 
+    };
 
     try {
-        // 3. Gửi dữ liệu lên API Backend (Đã sửa chuẩn đường dẫn)
-        const response = await fetch('/api/exam/submit', { 
+        // ---  POST tới /api/score ---
+        const response = await fetch('/api/score', { 
             method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify({
-                user_id: 2, 
-                test_id: 1, 
-                // answers: userAnswers 
-            })
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
         });
 
         const result = await response.json();
 
-        // 4. Nếu thành công, chuyển hướng sang trang KẾT QUẢ
-        if (result.status === 'success') {
-            // Chuyển hướng và truyền attempt_id do Backend vừa tạo ra
-            // Lưu ý: Tùy Backend của bạn trả về ID nằm ở result.attempt_id hay result.data.attempt_id nhé
-            const newAttemptId = result.attempt_id || (result.data && result.data.attempt_id);
-            
-            window.location.href = `/client/pages/results.php?attempt_id=${newAttemptId}`;
+        if (result.status === 'success' || response.ok) {
+            // Xóa sạch dữ liệu bài làm cũ
+            localStorage.removeItem(`exam_endTime_${uuid}`);
+            localStorage.removeItem(storageKey);
+
+            // ---  redirect sang results.php?attempt_id={uuid} ---
+            const attemptId = result.attempt_id || uuid;
+            window.location.href = `/client/pages/results.php?attempt_id=${attemptId}`;
         } else {
-            alert('Có lỗi xảy ra: ' + result.message);
+            alert('Có lỗi xảy ra: ' + (result.message || 'Lưu bài thất bại'));
         }
 
     } catch (error) {
         console.error('Lỗi khi nộp bài:', error);
         alert('Không thể kết nối đến máy chủ. Vui lòng thử lại sau!');
+    }
+}
+function clearExamData() {
+    const params = new URLSearchParams(window.location.search);
+    const uuid = params.get("uuid") || params.get("test_id");
+    if (uuid) {
+        localStorage.removeItem(`exam_endTime_${uuid}`);
+        localStorage.removeItem(`exam_answers_${uuid}`);
     }
 }

--- a/client/js/main.js
+++ b/client/js/main.js
@@ -1,10 +1,8 @@
-/*Khi load trang sẽ tự động lấy danh sách đề thi từ db*/
 document.addEventListener("DOMContentLoaded", function(){
     load_tests();
-})
+});
 
-
-/*Lấy danh sách đề thi và hiển thị lên trang user*/
+/* Lấy danh sách đề thi và hiển thị lên trang user */
 async function load_tests() {
     try {
         const response = await fetch('/api/tests/');
@@ -14,31 +12,41 @@ async function load_tests() {
 
         const test_list = await response.json();
         const tests = test_list.data;
-        //Chỉ hiện thi các đề thi active và không phải premiumb 
-        const visibleTests = tests.filter(test => Number(test.is_active) === 1 && test.is_unlocked === true);
-        //Số tests tối đa hiển thị trên một dòng
+        // CHỈ LỌC ĐỀ ACTIVE (Sẽ hiện cả Đề 1 Free và Đề 2 Premium)
+        const visibleTests = tests.filter(test => Number(test.is_active) === 1);
+        
         const MAX_COLS = 4;
-
         let test_grid = document.querySelector('.test-grid');
         test_grid.innerHTML = "";
 
-        //Mỗi row sẽ có 4 tests
         for (let i = 0; i < visibleTests.length; i += MAX_COLS) {
             let test_row = `<div class="test-row">`;
             for (let j = i; j < i + MAX_COLS && j < visibleTests.length; j++) {
+                let currentTest = visibleTests[j];
+
+                // Gắn mác Premium 
+                let premiumBadge = currentTest.is_premium 
+                    ? `<span class="badge bg-warning text-dark ml-2" style="font-size: 0.8rem;">Premium 👑</span>` 
+                    : '';
+
+                // Hiển thị nút bấm (Đã unlock thì Start Test, chưa thì bắt Đăng ký)
+                let actionButton = currentTest.is_unlocked 
+                    ? `<a href="./exam.php?uuid=${currentTest.uuid}" class="btn btn-outline-primary mt-auto enter-test">Start test</a>`
+                    : `<a href="./premium.php" class="btn btn-warning mt-auto enter-test"><i class="fas fa-lock mr-1"></i> Đăng ký Premium</a>`;
+
                 test_row += `
                     <div class="test-item">
                         <div class="card exam-card">
                             <div class="card-body d-flex flex-column">
-                                <h5 class="card-title"><b>${visibleTests[j].title}</b></h5>
+                                <h5 class="card-title"><b>${currentTest.title}</b> ${premiumBadge}</h5>
                                 <div class="test-meta">
                                     <span class="testitem-info">
                                         <span class="far fa-clock mr-1"></span>
                                     </span>
-                                    <span class="testitem-info">${visibleTests[j].duration / 60} minutes | ${visibleTests[j].total_questions} questions</span>
+                                    <span class="testitem-info">${currentTest.duration / 60} minutes | ${currentTest.total_questions} questions</span>
                                 </div>
-                                <p class="card-text">${visibleTests[j].description}</p>
-                                <a href="./exam.php?uuid=${visibleTests[j].uuid}" class="btn btn-outline-primary mt-auto enter-test">Start test</a>
+                                <p class="card-text">${currentTest.description}</p>
+                                ${actionButton}
                             </div>
                         </div>
                     </div>

--- a/client/pages/components/navBar.php
+++ b/client/pages/components/navBar.php
@@ -45,6 +45,6 @@
   </nav>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
-  <script src="../js/main/main.js"></script>
+  <script src="../js/main.js"></script>
 </body>
 </html>

--- a/client/pages/exam.php
+++ b/client/pages/exam.php
@@ -92,7 +92,6 @@
     </div>
 
     <script src="../js/exam.js"></script>
-    <script src="../js/data.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 

--- a/client/pages/exam.php
+++ b/client/pages/exam.php
@@ -3,7 +3,7 @@
 
 <head>
     <?php include './components/metadata.php'; ?>
-    <title></title>
+    <title>Làm bài thi TOEIC | PREPHUB</title>
     <link rel="stylesheet" href="../styles/examStyle.css" />
 </head>
 
@@ -11,7 +11,7 @@
 
     <header class="top-header text-center shadow-sm">
         <span class="fw-bold fs-5 me-3" id="exam-title"></span>
-        <a href="user.php" class="btn btn-outline-secondary btn-sm">Thoát</a>
+        <a href="user.php" class="btn btn-outline-secondary btn-sm" onclick="clearExamData()">Thoát</a>    
     </header>
 
     <div class="container-fluid py-4 px-lg-5">
@@ -55,8 +55,12 @@
                 <div class="sidebar shadow-sm">
                     <div class="text-center mb-4">
                         <p class="mb-1 text-muted">Thời gian còn lại:</p>
-                        <h3 class="fw-bold mb-3" id="timer-display"></h3>
-                        <button class="btn btn-primary fw-bold w-100 py-2 submit-btn">SUBMIT</button>
+                        <h3 class="fw-bold mb-3" id="timer-display">--:--</h3>
+                        
+                        <!--  Thêm data-bs-toggle để gọi Modal xác nhận -->
+                        <button class="btn btn-primary fw-bold w-100 py-2 submit-btn" data-bs-toggle="modal" data-bs-target="#confirmSubmitModal">
+                            SUBMIT
+                        </button>
                     </div>
 
                     <hr>
@@ -66,8 +70,30 @@
         </div>
     </div>
 
+    <!-- TÍNH NĂNG MỚI: Thêm khối Modal của Bootstrap để xác nhận nộp bài -->
+    <div class="modal fade" id="confirmSubmitModal" tabindex="-1" aria-labelledby="confirmSubmitModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title fw-bold text-primary" id="confirmSubmitModalLabel">Xác nhận nộp bài</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    Bạn có chắc chắn muốn nộp bài ngay bây giờ? <br>
+                    <small class="text-danger">Lưu ý: Bạn không thể thay đổi đáp án sau khi đã nộp.</small>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal"> Quay lại</button>
+                    <!-- Gắn sự kiện onclick gọi hàm submitExam() trong exam.js -->
+                    <button type="button" class="btn btn-primary fw-bold" onclick="submitExam()">Đồng ý </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script src="../js/exam.js"></script>
     <script src="../js/data.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 
 </html>

--- a/client/pages/home.php
+++ b/client/pages/home.php
@@ -54,7 +54,6 @@
   <!-- INCLUDE FOOTER FILE -->
   <?php include './components/footer.php'; ?>
 
-  <script src="../js/data.js"></script>
   <script src="../js/main.js"></script>
 </body>
 

--- a/server/controllers/score-controller.php
+++ b/server/controllers/score-controller.php
@@ -1,32 +1,89 @@
 <?php
-// xử lí logic api nộp bài, chấm điểm, thống kê
-// server/controllers/score-controller.php
+// Xử lý logic API nộp bài, chấm điểm, thống kê
 require_once __DIR__ . '/../db/config.php';
-require_once __DIR__ . '/../models/attempt.php';
-// Cấp quyền CORS nếu client gọi từ port khác
+require_once __DIR__ . '/../models/Attempt.php';
+
 header('Content-Type: application/json; charset=utf-8');
 
-try {
-    // Lấy attempt_id từ URL (VD: api.php?action=get_results&attempt_id=123)
-    $attempt_id = isset($_GET['attempt_id']) ? (int)$_GET['attempt_id'] : 0;
+$attemptModel = new Attempt($conn);
+$method = $_SERVER['REQUEST_METHOD'];
 
-    if ($attempt_id === 0) {
-        http_response_code(400);
-        echo json_encode(['error' => 'Thiếu attempt_id']);
+try {
+    // ==========================================
+    // LUỒNG 1: XỬ LÝ NỘP BÀI (METHOD POST)
+    // ==========================================
+    if ($method === 'POST') {
+        // Đọc dữ liệu JSON từ Frontend gửi lên
+        $inputJSON = file_get_contents('php://input');
+        $data = json_decode($inputJSON, true);
+
+        // Kiểm tra xem có test_uuid hay không
+        $test_uuid = isset($data['test_uuid']) ? $data['test_uuid'] : '';
+        $answers = isset($data['answers']) ? $data['answers'] : [];
+
+        if (empty($test_uuid)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Thiếu test_uuid để chấm điểm']);
+            exit;
+        }
+
+        // 1. Khởi động Session an toàn (Chỉ mở nếu chưa mở)
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        // 2. Lấy thẳng user_id vì logic đã bắt đăng nhập từ đầu
+        $user_id = isset($_SESSION['user_id']) ? $_SESSION['user_id'] : null;
+
+        // Bắt lỗi hy hữu: Đang làm bài mà rớt mạng hoặc Session bị hết hạn (Timeout)
+        if (!$user_id) {
+            http_response_code(401); 
+            echo json_encode(['error' => 'Phiên đăng nhập đã hết hạn. Vui lòng tải lại trang và đăng nhập lại!']);
+            exit;
+        }
+
+        // 3. Gọi hàm chấm điểm và lưu DB trong Model
+        $real_attempt_id = $attemptModel->submitAndGrade($user_id, $test_uuid, $answers);
+
+        // Xử lý kết quả trả về
+        if (!$real_attempt_id) {
+            http_response_code(500);
+            echo json_encode(['error' => 'Chấm điểm thất bại hoặc lỗi lưu Database!']);
+            exit;
+        }
+
+        // 4. Trả về cho JS ID thật để nó chuyển trang
+        http_response_code(200);
+        echo json_encode([
+            'status' => 'success',
+            'message' => 'Nộp bài và chấm điểm thành công!',
+            'attempt_id' => $real_attempt_id 
+        ]);
+        exit;
+    } 
+    // ==========================================
+    // LUỒNG 2: XỬ LÝ XEM KẾT QUẢ (METHOD GET - CODE CŨ CỦA ÔNG)
+    // ==========================================
+    else if ($method === 'GET') {
+        // Có thể trang results.php sẽ truyền uuid chứ không phải số int
+        $attempt_id = isset($_GET['attempt_id']) ? $_GET['attempt_id'] : '';
+
+        if (empty($attempt_id)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Thiếu attempt_id']);
+            exit;
+        }
+
+        // Gọi hàm fetch data từ Model của ông
+        $results = $attemptModel->getReviewDetails($attempt_id);
+
+        http_response_code(200);
+        echo json_encode([
+            'status' => 'success',
+            'data' => $results
+        ]);
         exit;
     }
-
-    $attemptModel = new Attempt($conn);
-    
-    // Gọi hàm fetch data
-    $results = $attemptModel->getReviewDetails($attempt_id);
-
-    // Trả về JSON 
-    http_response_code(200);
-    echo json_encode([
-        'status' => 'success',
-        'data' => $results
-    ]);
 
 } catch (Exception $e) {
     http_response_code(500);

--- a/server/controllers/score-controller.php
+++ b/server/controllers/score-controller.php
@@ -1,7 +1,7 @@
 <?php
 // Xử lý logic API nộp bài, chấm điểm, thống kê
 require_once __DIR__ . '/../db/config.php';
-require_once __DIR__ . '/../models/Attempt.php';
+require_once __DIR__ . '/../models/attempt.php';
 
 header('Content-Type: application/json; charset=utf-8');
 

--- a/server/models/attempt.php
+++ b/server/models/attempt.php
@@ -70,5 +70,91 @@ class Attempt {
 
         return $questions;
     }
+    public function submitAndGrade($user_id, $test_uuid, $user_answers) {
+        try {
+            // Bước 1: Lấy ID thật của đề thi
+            $stmt = $this->db->prepare("SELECT id FROM tests WHERE uuid = ?");
+            $stmt->execute([$test_uuid]);
+            $test = $stmt->fetch(PDO::FETCH_ASSOC);
+            if (!$test) return false;
+            $test_id = $test['id'];
+
+            // Bước 2: Lấy đáp án chuẩn 
+            $stmt = $this->db->prepare("SELECT id as question_id, question_number, correct_answer, part FROM questions WHERE test_id = ?");
+            $stmt->execute([$test_id]);
+            $correct_answers = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            $listening_correct = 0;
+            $reading_correct = 0;
+            
+            // Mảng lưu chi tiết từng câu để chuẩn bị insert
+            $details_data = [];
+
+            // Bước 3: Vòng lặp chấm điểm
+            foreach ($correct_answers as $row) {
+                $qId = $row['question_id'];
+                $qNum = $row['question_number'];
+                $correctOption = $row['correct_answer'];
+                $part = (int)$row['part'];
+
+                // Kiểm tra xem user có chọn câu này không
+                $user_choice = isset($user_answers[$qNum]) ? $user_answers[$qNum] : null;
+                $is_correct = ($user_choice === $correctOption) ? 1 : 0;
+
+                // Cộng điểm nếu đúng
+                if ($is_correct) {
+                    if ($part >= 1 && $part <= 4) {
+                        $listening_correct++;
+                    } else if ($part >= 5 && $part <= 7) {
+                        $reading_correct++;
+                    }
+                }
+
+                // Đưa vào danh sách chi tiết
+                $details_data[] = [
+                    'question_id' => $qId,
+                    'selected_answer' => $user_choice,
+                    'is_correct' => $is_correct
+                ];
+            }
+
+            // Bước 4: Quy đổi điểm chuẩn
+            $listening_score = $listening_correct * 5;
+            $reading_score = $reading_correct * 5;
+            $total_score = $listening_score + $reading_score;
+
+            // Bước 5: LƯU TỔNG ĐIỂM VÀO BẢNG ATTEMPTS
+            $insert_sql = "INSERT INTO attempts (uuid, user_id, test_id, listening_correct, reading_correct, listening_score, reading_score, total_score, time_spent, created_at) 
+                           VALUES (UUID(), ?, ?, ?, ?, ?, ?, ?, 0, NOW())";
+            $stmt = $this->db->prepare($insert_sql);
+            $stmt->execute([$user_id, $test_id, $listening_correct, $reading_correct, $listening_score, $reading_score, $total_score]);
+            
+            // Lấy ID của bài thi vừa lưu xong
+            $attempt_id = $this->db->lastInsertId();
+
+            // ==========================================
+            // BƯỚC 6 (MỚI): LƯU CHI TIẾT VÀO BẢNG ATTEMPT_ANSWERS
+            // Để trang Review biết câu nào đúng, câu nào sai
+            // ==========================================
+            if (!empty($details_data)) {
+                $insert_detail_sql = "INSERT INTO attempt_answers (attempt_id, question_id, selected_answer, is_correct) VALUES (?, ?, ?, ?)";
+                $detail_stmt = $this->db->prepare($insert_detail_sql);
+                
+                foreach ($details_data as $detail) {
+                    $detail_stmt->execute([
+                        $attempt_id,
+                        $detail['question_id'],
+                        $detail['selected_answer'],
+                        $detail['is_correct']
+                    ]);
+                }
+            }
+
+            return $attempt_id; 
+
+        } catch (PDOException $e) {
+            throw new Exception("Lỗi SQL: " . $e->getMessage());
+        }
+    }
 }
 ?>


### PR DESCRIPTION
- Sửa lỗi gọi API (đổi sang đường dẫn `/api/tests/{uuid}`).
- Thêm tính năng chặn user chưa mua vào làm đề Premium (redirect sang trang nâng cấp).
- Cập nhật hàm đếm ngược thời gian, kết hợp `localStorage` để chống hack giờ và chống mất đáp án khi lỡ bấm F5.
- Cập nhật logic nộp bài, tự động gom đáp án gọi API POST tới `/api/score` và redirect sang trang kết quả.
- Tích hợp Modal xác nhận nộp bài (Bootstrap).